### PR TITLE
Workflow improvements: Fails less often

### DIFF
--- a/.github/workflows/test-build-dev.yml
+++ b/.github/workflows/test-build-dev.yml
@@ -6,9 +6,30 @@ on:
   pull_request: # Validate proposed changes
     branches:
       - dev
+    paths:
+      - docs/*
+      - src/*
+      - static/*
+      - versioned_docs/*
+      - versioned_sidebars/*
+      - babel.config.js
+      - docusaurus.config.js
+      - sidebars.js
+      - versions.json
+
   push:         # Validate incoming changes
     branches:
       - dev
+    paths:
+      - docs/*
+      - src/*
+      - static/*
+      - versioned_docs/*
+      - versioned_sidebars/*
+      - babel.config.js
+      - docusaurus.config.js
+      - sidebars.js
+      - versions.json
   
   workflow_dispatch:  # Allow manual re-run from Actions tab
 

--- a/.github/workflows/test-build-main.yml
+++ b/.github/workflows/test-build-main.yml
@@ -6,9 +6,30 @@ on:
   pull_request: # Validate proposed changes
     branches:
       - main
+    paths:
+      - docs/*
+      - src/*
+      - static/*
+      - versioned_docs/*
+      - versioned_sidebars/*
+      - babel.config.js
+      - docusaurus.config.js
+      - sidebars.js
+      - versions.json
+
   push:         # Validate changes set for deployment
     branches:
       - main
+    paths:
+      - docs/*
+      - src/*
+      - static/*
+      - versioned_docs/*
+      - versioned_sidebars/*
+      - babel.config.js
+      - docusaurus.config.js
+      - sidebars.js
+      - versions.json
   
   workflow_dispatch:  # Allow manual re-run from Actions tab
 


### PR DESCRIPTION
Added more conditions to the test build workflows, so they won't run in as many situations where they're guaranteed to fail because they didn't need to run anyway.

Did this using path conditions. Test builds will only run when build-relevant files change.

Also renamed test-deploy-[etc] --> test-build-[etc]